### PR TITLE
up play-services-location to 21.0.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,5 +38,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.google.android.gms:play-services-location:17.1.0'
+    implementation 'com.google.android.gms:play-services-location:21.0.1'
 }


### PR DESCRIPTION
An error was occurring when building an app with react native on version 0.74.3 and node 18+, where it was necessary to update the google-play-service-location library for the error to stop happening.